### PR TITLE
Fix some wrong assigments and vertical interp

### DIFF
--- a/enkf/common/grid.c
+++ b/enkf/common/grid.c
@@ -854,7 +854,6 @@ static double z2fk_basic(int n, double* zt, double* zc, double z)
           zdist = zt[i1]-z;
           cell_height = zt[i1]-zt[i1+1];
           ival = i1 + zdist/cell_height;
-          fprintf(stdout,"value is below zc[%d]=%f!fk=%f\n",i1+1,zc[i1+1],ival);
           return ival;
 
         /* //WHY use zc!? */


### PR DESCRIPTION
Hi @sakov,

I can see some code changes are happening quickly over the last weeks.

I was testing the 1.79.8 code with sigma grids and was not getting the expected results over the vertical
. I went through to update the code and found some wrong assignments in HEAD with the new variables names for sigma coordinates. I also did some refactoring in the vertical interpolation routine. Now I can get the *exact* vertical fractional indexes as in linear interpolation for my case (sigma). Not sure if the code below affects other cases.