### PR TITLE
fix std/estd/qcflag logic

### DIFF
--- a/enkf/prep/reader_xy_gridded.c
+++ b/enkf/prep/reader_xy_gridded.c
@@ -339,8 +339,9 @@ void reader_xy_gridded(char* fname, int fid, obsmeta* meta, grid* g, observation
 
         if ((npoints != NULL && npoints[i] == 0) || var[i] == var_fill_value || isnan(var[i]) || (std != NULL && (std[i] == std_fill_value || isnan(std[i]))) || (estd != NULL && (estd[i] == estd_fill_value || isnan(estd[i]))) || (have_time && !singletime && (time[i] == time_fill_value || isnan(time[i]))))
             continue;
-        if (qcflag != NULL && !(qcflag[i] | qcflagvals))
+        if (qcflag != NULL && (qcflagvals != (qcflagvals | 1<<qcflag[i])))
             continue;
+
 
         nobs_read++;
         obs_checkalloc(obs);
@@ -358,8 +359,12 @@ void reader_xy_gridded(char* fname, int fid, obsmeta* meta, grid* g, observation
             o->value = (double) (var[i] * var_scale_factor + var_add_offset + varshift);
         else
             o->value = (double) (var[i] + varshift);
-        if (estd == NULL)
-            o->std = var_estd;
+        if (estd == NULL && std == NULL){
+            if (!isnan(var_estd))
+                o->std = var_estd;
+            else
+                enkf_quit("Aborted. error_std is missing for for product %s in obs.prm.",meta->product);
+        }
         else {
             if (std == NULL)
                 o->std = 0.0;
@@ -369,12 +374,13 @@ void reader_xy_gridded(char* fname, int fid, obsmeta* meta, grid* g, observation
                 else
                     o->std = (double) std[i];
             }
-            if (!isnan(estd_add_offset)) {
-                double std2 = (double) (estd[i] * estd_scale_factor + estd_add_offset);
-
-                o->std = (o->std > std2) ? o->std : std2;
-            } else
-                o->std = (o->std > estd[i]) ? o->std : estd[i];
+            if (estd != NULL) {
+                if (!isnan(estd_add_offset)) {
+                    double std2 = (double) (estd[i] * estd_scale_factor + estd_add_offset);
+                    o->std = (o->std > std2) ? o->std : std2;
+                } else
+                    o->std = (o->std > estd[i]) ? o->std : estd[i];
+            }
         }
         if (iscurv == 0) {
             o->lon = lon[i % ni];


### PR DESCRIPTION
Hi,

When implementing some readers/headers I notice that the logic for std/estd/qcflags in HEAD was slightly incorrect or was causing segfaults. This PR correct some of the logic.

Top to bot:

block 1 - The binary logic is wrong. The proper expression is provided to select only the input flags user requested by setting PARAMETER QCFLAGSVALS in obs.prm. With the logic below we can now:

```
PARAMETER QCFLAGNAMES "var_quality_flag"
PARAMETER QCFLAGSVALS 0, 3, 6, 9
```
in obs.prm and only the above quality flags will be selected.

block 2  - When estd is not defined, but std is provided, the if clause cause all std values to be set to 0. 
prep will also quit earlier in the right place when no std/estd and/or error_std attribute is missing.

block 3 - Only access/process estd when it is defined by the user, otherwise, segfault occurs.

As you can see, I only changed in reader_xy_gridded.c. This change will probably spread over all the other readers.
