### PR TITLE
Improvement: add support to read opendap addresses in obs.prm

### DIFF
--- a/enkf/common/utils.c
+++ b/enkf/common/utils.c
@@ -275,8 +275,6 @@ void find_files(char* template, int* nfiles, char*** fnames)
 {
     glob_t gl;
     int status;
-    char http_str[4];
-    strncpy(http_str,template,4);
 
     status = glob(template, GLOB_PERIOD | GLOB_TILDE_CHECK, NULL, &gl);
     if (status == GLOB_NOSPACE || status == GLOB_ABORTED || status == GLOB_ERR) {
@@ -297,7 +295,7 @@ void find_files(char* template, int* nfiles, char*** fnames)
         *nfiles += gl.gl_pathc;
     globfree(&gl);
     }
-    else if (strcasecmp(http_str,"http") == 0){
+    else if (strncasecmp(template,"http",4) == 0){
         
         if (*nfiles == 0)
             *fnames = NULL;

--- a/enkf/common/utils.c
+++ b/enkf/common/utils.c
@@ -275,6 +275,8 @@ void find_files(char* template, int* nfiles, char*** fnames)
 {
     glob_t gl;
     int status;
+    char http_str[4];
+    strncpy(http_str,template,4);
 
     status = glob(template, GLOB_PERIOD | GLOB_TILDE_CHECK, NULL, &gl);
     if (status == GLOB_NOSPACE || status == GLOB_ABORTED || status == GLOB_ERR) {
@@ -282,6 +284,7 @@ void find_files(char* template, int* nfiles, char*** fnames)
 
         enkf_quit("failed looking for \"%s\": %s", template, strerror(errno_saved));
     }
+
 
     if (gl.gl_pathc > 0) {
         int i, ii;
@@ -292,8 +295,17 @@ void find_files(char* template, int* nfiles, char*** fnames)
         for (i = 0, ii = *nfiles; i < gl.gl_pathc; ++i, ++ii)
             (*fnames)[ii] = strdup(gl.gl_pathv[i]);
         *nfiles += gl.gl_pathc;
-    }
     globfree(&gl);
+    }
+    else if (strcasecmp(http_str,"http") == 0){
+        
+        if (*nfiles == 0)
+            *fnames = NULL;
+        *fnames = realloc(*fnames, (*nfiles + 1) * sizeof(void*));
+        (*fnames)[*nfiles] = strdup(template);
+        *nfiles += 1;
+    }
+
 }
 #else
 /** Find files matching the template using "ls".


### PR DESCRIPTION
This PR just provide a bypass in the glob processing if the file entry in obs.prm start with an "HTTP" string. 

This way, we can access opendap files directly via NetCDF C API.
The access is weak and prone to fail, however, given the C API handle of opendap access is not complete (see https://github.com/Unidata/netcdf-c/issues/1074 ).