### PR TITLE
Support several qcflags

### DIFF
--- a/enkf/prep/obsprm.c
+++ b/enkf/prep/obsprm.c
@@ -143,7 +143,7 @@ void obsprm_read(char fname[], int* nmeta, obsmeta** meta)
             else
                 enkf_quit("%s, l.%d: parameter value not specified (expected: PARAMETER <name> = <value>)", fname, line);
             while ((token = strtok(NULL, seps)) != NULL) {
-                now->value = realloc(now->value, strlen(token) + 2);
+                now->value = realloc(now->value, strlen(now->value) + strlen(token) + 2);
                 strcat(now->value, " ");
                 strcat(now->value, token);
             }


### PR DESCRIPTION
Hi @pavel,

as discussed in #12, This PR implement the support to several qcflags in the generic gridded reader. 


Let me know if you are willing to accept so I can propagate to other readers and finish the request.

First commit is a has a small fix in obsprm.c since the code was hitting the end of the string and the second one the actual support in the reader.