### PR TITLE
bugfix: qcflags are forgotten after file loop

### DIFF
--- a/enkf/prep/reader_xy_gridded.c
+++ b/enkf/prep/reader_xy_gridded.c
@@ -126,8 +126,11 @@ void reader_xy_gridded(char* fname, int fid, obsmeta* meta, grid* g, observation
         else if (strcasecmp(meta->pars[i].name, "QCFLAGNAME") == 0)
             qcflagname = meta->pars[i].value;
         else if (strcasecmp(meta->pars[i].name, "QCFLAGVALS") == 0) {
+            char* pline = meta->pars[i].value;
+            int linelen = sizeof(pline);
+            char lineval[linelen];
+            char* line = strcpy(lineval,pline);
             char seps[] = " ,";
-            char* line = meta->pars[i].value;
             char* token;
             int val;
 


### PR DESCRIPTION
Hi,

this small PR fix a problem I was encountering with qcflags. When prep was reading several files, the valid qcflags were forgotten in the sequential files. This was because ```line``` is changed in place and set to NULL.
Now the operation is made on a copied str.

This enable support of the qcflagvals for all subsequential files in:

```
...
parameter qcflagvals = 1, 2, 3 ,4 
file=a.nc
file=b.nc
file=c.nc
```


Let me know if I should expand to the others readers.